### PR TITLE
Stop iterating objects using __proto__

### DIFF
--- a/console.js
+++ b/console.js
@@ -105,16 +105,9 @@
 
         function getProps(obj) {
             var props = [];
-
-            do {
-                for (var prop in obj) {
-                    if (props.indexOf(prop) === -1) {
-                        props.push(prop);
-                    }
-                }
+            for (var prop in obj) {
+                props.push(prop);
             }
-            while (obj = obj.__proto__);
-
             return props;
         }
 


### PR DESCRIPTION
`__proto__` is not standard (is only defined in an annex for compatibility), and thus should be avoided. Moreover, not all objects inherit `__proto__` from `Object.prototype`.

And it's pointless, because `for...in` loops already iterate inherited properties.
