### PR TITLE
Adds support for BigInt

### DIFF
--- a/console.js
+++ b/console.js
@@ -64,6 +64,7 @@
         ".as-console-collapsed-value .as-console-ellipsis { display: inline; }",
         ".as-console-type-label, .as-console-nil-value { color: #808080; }",
         ".as-console-literal-value, .as-console-expandable-value .as-console-string-value { color: #C00; }",
+        ".as-console-bigint-value { color: #005d00; }",
         ".as-console-expandable-value .as-console-string-value::before, .as-console-expandable-value .as-console-string-value::after { content: '\"'; color: #000; }",
         ".as-console-keyword { color: #00F; }",
         ".as-console-non-enumerable-value > .as-console-dictionary-label { color: #b571be; }",
@@ -315,6 +316,10 @@
                 case 'Number':
                     span.textContent = String(value);
                     span.classList.add("as-console-keyword");
+                    break;
+                case 'BigInt':
+                    span.textContent = value + 'n';
+                    span.classList.add("as-console-bigint-value");
                     break;
                 default:
                     if (value instanceof Error) {


### PR DESCRIPTION
BigInt is currently a Stage 3 proposal, although it is already implemented in V8 and has been in [Chrome since version 67](https://developers.google.com/web/updates/2018/05/nic67#bigint).

Currently if you log a BigInt you get the expandable form `BigInt { ... }` and when you click to expand it nothing happens, and an error is thrown from using a primitive as a WeakMap key.

This adds support for BigInts, and displays them consistently with Chrome DevTools